### PR TITLE
Hide Dependencies

### DIFF
--- a/src/dtls_srtp.c
+++ b/src/dtls_srtp.c
@@ -189,6 +189,8 @@ int dtls_srtp_init(DtlsSrtp *dtls_srtp, DtlsSrtpRole role, void *user_data) {
   dtls_srtp->mbedtls_ctx = malloc(sizeof(MbedtlsContext));
   MbedtlsContext *mbedtls_ctx = (MbedtlsContext *)dtls_srtp->mbedtls_ctx;
 
+  dtls_srtp->srtp_ctx = malloc(sizeof(SRTPContext));
+
   mbedtls_ssl_config_init(&mbedtls_ctx->conf);
   mbedtls_ssl_init(&mbedtls_ctx->ssl);
 
@@ -271,6 +273,9 @@ void dtls_srtp_deinit(DtlsSrtp *dtls_srtp) {
     srtp_dealloc(srtp_ctx->srtp_in);
     srtp_dealloc(srtp_ctx->srtp_out);
   }
+
+  free(dtls_srtp->mbedtls_ctx);
+  free(dtls_srtp->srtp_ctx);
 }
 
 static void dtls_srtp_key_derivation(void *context, mbedtls_ssl_key_export_type secret_type,

--- a/src/dtls_srtp.h
+++ b/src/dtls_srtp.h
@@ -4,17 +4,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <mbedtls/entropy.h>
-#include <mbedtls/ctr_drbg.h>
-#include <mbedtls/ssl.h>
-#include <mbedtls/ssl_cookie.h>
-#include <mbedtls/pk.h>
-#include <mbedtls/x509_crt.h>
-#include <mbedtls/x509_csr.h>
-#include <mbedtls/timing.h>
-
-#include <srtp2/srtp.h>
-
 #include "address.h"
 
 #define SRTP_MASTER_KEY_LENGTH  16
@@ -40,19 +29,11 @@ typedef enum DtlsSrtpState {
 typedef struct DtlsSrtp {
 
   // MbedTLS
-  mbedtls_ssl_context ssl;
-  mbedtls_ssl_config conf;
-  mbedtls_ssl_cookie_ctx cookie_ctx;
-  mbedtls_x509_crt cert;
-  mbedtls_pk_context pkey;
-  mbedtls_entropy_context entropy;
-  mbedtls_ctr_drbg_context ctr_drbg;
+  void* mbedtls_ctx;
 
   // SRTP
-  srtp_policy_t remote_policy;
-  srtp_policy_t local_policy;
-  srtp_t srtp_in;
-  srtp_t srtp_out;
+  void* srtp_ctx;
+
   unsigned char remote_policy_key[SRTP_MASTER_KEY_LENGTH + SRTP_MASTER_SALT_LENGTH];
   unsigned char local_policy_key[SRTP_MASTER_KEY_LENGTH + SRTP_MASTER_SALT_LENGTH];
 


### PR DESCRIPTION
Use P-Impl strategy to hide away srtp and mbedtls dependencies from integrators